### PR TITLE
Fixed README typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ version: 0.16.0
 git clone https://github.com/Lamden/wallet.git
 cd wallet
 ```
-### Install package dependancies
+### Install package dependencies
 ```
 sudo npm install
 ```


### PR DESCRIPTION
I was able to fix a typo in the `README.md` file in which "dependencies" was spelled "dependancies".