### PR TITLE
wallet misspelling "Currencly" on wallet options

### DIFF
--- a/src/svelte/coins/CoinOptions.svelte
+++ b/src/svelte/coins/CoinOptions.svelte
@@ -214,7 +214,7 @@ h2{
         <DropDown
             id={'dapps-dd'}
             items={dAppList} 
-            label={'Currencly Linked Apps'}
+            label={'Currently Linked Apps'}
             margin="0 0 2rem"
             on:selected={(e) => associateDapp(e.detail.selected.value)}
         />


### PR DESCRIPTION
There are a misspelling on any wallet options "Currencly" -> "Currently"