### PR TITLE
allow calling approve fn on any contract

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "lamden-wallet",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/js/backgroundControllers/masterController.js
+++ b/src/js/backgroundControllers/masterController.js
@@ -157,7 +157,7 @@ export const masterController = () => {
                 //Set senderVk to the one assocated with this dapp
                 txInfo.senderVk = wallet.vk;
                 //Allow approval requests to be submitted without hardcoding the approved smart contract
-                if (txInfo.contractName === "currency" && txInfo.methodName === "approve"){
+                if (txInfo.methodName === "approve"){
                     approvalRequest = true;
                     txInfo.kwargs.to = dappInfo[txInfo.networkType].contractName;
                 }else{


### PR DESCRIPTION
I discovered a limitation in the wallet while working on the rocketswap frontend, approval requests for the token contract were being replaces with 'con_amm2'; the name of the application contract.

This code change solves this issue, but IDK what the implications of this change could mean from a security standpoint.