### PR TITLE
Hotfix v1.9.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
   "name": "lamden-wallet",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "description": "A wallet for interacting with contracts on the Lamden blockchain.",
   "author": "Jeff Scott <jeff@lamden.io>",
   "license": "",
   "scripts": {
     "build": "node utils/build.js",
-    "tests": "mocha --recursive --timeout 30000 selenium/tests/",
+    "tests": "npm run build && mocha --recursive --timeout 30000 selenium/tests/",
     "test-firstrun": "mocha --recursive --timeout 30000 selenium/tests/ui/firstrun/*.js",
     "test-firstrun-new": "mocha --recursive --timeout 30000 selenium/tests/ui/firstrun/FirstRun_CreateWallet.js",
     "test-firstrun-restore": "mocha --recursive --timeout 30000 selenium/tests/ui/firstrun/FirstRun_RestoreWallet.js",

--- a/selenium/tests/ui/tokens/tokens-transactions.js
+++ b/selenium/tests/ui/tokens/tokens-transactions.js
@@ -76,6 +76,37 @@ const whitelabel = require('../../../../whitelabel.json')
                 await helpers.sleep(500)
                 await helpers.gotoAccountsPage(driver)
             });
+            it('Simple Transaction UI: Renders confirm modal if receiving address is not Lamdenkey', async function() {
+                const to = 'xxxxxx'
+                let token = tokenInfo.token_1_svg
+                await helpers.sleep(500)
+                await tokenHelpers.gotoTokenDetails(driver, token)
+                await driver.wait(until.elementLocated(By.id('transfer-token-btn')), 5000).click();
+                await helpers.sleep(4000);
+                await driver.wait(until.elementLocated(By.id('amount')), 5000).sendKeys(`1`);
+                await driver.wait(until.elementLocated(By.id('receiver-input')), 5000).sendKeys(to);
+                await driver.wait(until.elementLocated(By.id('lamden-tx-next-btn')), 5000).click();
+                const text = await driver.wait(until.elementLocated(By.css('.notification .msg')), 5000).getText();
+                assert.equal(`The receiving address ${to} is not Lamben's address. This may cause you to lose your funds!`, text)
+                await tokenHelpers.cancelTransferModal(driver)
+                await helpers.gotoAccountsPage(driver)
+            });
+            it('Advanced Transaction UI: Renders confirm modal if receiving address is not Lamdenkey', async function() {
+                const to = 'xxxxxx'
+                let token = tokenInfo.token_1_svg
+                await helpers.sleep(500)
+                await tokenHelpers.gotoTokenDetails(driver, token)
+                await driver.wait(until.elementLocated(By.id('transfer-token-btn')), 5000).click();
+                await driver.wait(until.elementLocated(By.id('advanced')), 5000).click();
+                await helpers.sleep(4000);
+                await driver.wait(until.elementLocated(By.id('kwarg-0')), 5000).sendKeys(`1`);
+                await driver.wait(until.elementLocated(By.id('kwarg-1')), 5000).sendKeys(to);
+                await driver.wait(until.elementLocated(By.id('lamden-tx-next-btn')), 5000).click();
+                const text = await driver.wait(until.elementLocated(By.css('.notification .msg')), 5000).getText();
+                assert.equal(`The receiving address ${to} is not Lamben's address. This may cause you to lose your funds!`, text)
+                await tokenHelpers.cancelTransferModal(driver)
+                await helpers.gotoAccountsPage(driver)
+            });
         })
     
         context('token approve', function() {

--- a/src/svelte/Router.svelte
+++ b/src/svelte/Router.svelte
@@ -43,6 +43,7 @@ import CoinDelete from './coins/CoinDelete.svelte';
 import CoinDeleting from './coins/CoinDeleting.svelte'; 
 import CoinHistory from  './coins/CoinHistory.svelte'; 
 import CoinLamdenReceive from './coins/CoinLamdenReceive.svelte';
+import ConiLamdenSendWarningBox from './coins/ConiLamdenSendWarningBox.svelte';
 
 //Backup and Restore
 import Backup from './backup_restore/Backup.svelte';
@@ -222,6 +223,7 @@ export const Components = {
 };
 
 export const Modals = {
+    ConiLamdenSendWarningBox,
     CoinLamdenSend, TokenLamdenSend,
     CoinModify, CoinOptions, CoinDelete, CoinDeleting, CoinEditNickname,
     TokenModify, TokenOptions, TokenDelete, TokenDeleting,

--- a/src/svelte/coins/CoinLamdenContract.svelte
+++ b/src/svelte/coins/CoinLamdenContract.svelte
@@ -73,7 +73,7 @@
         let bal = BalancesStore.getBalance($currentNetwork, selectedWallet.vk)
         
         let userStampsAvailable = bal.multipliedBy(stampRatio)
-        if (maxStamps.isGreaterThan(userStampsAvailable)) {
+        if (maxStamps !== 0 && maxStamps.isGreaterThan(userStampsAvailable)) {
             stampLimit = parseInt(userStampsAvailable.toString())
         }
         else stampLimit = parseInt(maxStamps.toString())
@@ -285,7 +285,7 @@
                 width={'232px'}
                 margin={'0 0 17px 0'}
                 name="Next" 
-                click={() => handleNext(2)} />
+                click={() => handleNext()} />
     </div>
 </div>
 

--- a/src/svelte/coins/CoinLamdenSend.svelte
+++ b/src/svelte/coins/CoinLamdenSend.svelte
@@ -8,6 +8,9 @@
     const { CoinLamdenContract, CoinLamdenSimpleContract } = Modals
     const { Button } = Components
 
+    //Utils
+    import { isLamdenKey } from '../../js/utils.js';
+
     //Context
 	const { closeModal } = getContext('app_functions');
 
@@ -23,6 +26,7 @@
     let steps = [
         {page: 'CoinLamdenSimpleContract', back: -1, cancelButton: true},
         {page: 'CoinLamdenContract', back: -1, cancelButton: true},
+        {page: 'ConiLamdenSendWarningBox', back: -1, cancelButton: true},
         {page: 'CoinConfirmTx', back: 0, cancelButton: true},
         {page: 'CoinSendingTx', back: -1, cancelButton: false},
         {page: 'ResultBox', back: -1, cancelButton: false}
@@ -31,6 +35,14 @@
             {name: 'Home', click: () => closeModal(), class: 'button__solid button__primary'},
             {name: 'New Transaction', click: () => currentStep = 1, class: 'button__solid'}
         ]
+    let message = {
+            title: "Are you sure to continue?",
+            text: "The receiving address is not Lamben's address. This may cause you to lose your funds!",
+            buttons: [
+                {name: 'Continue', click: () => nextPage(), class: 'button__solid button__primary'},
+                {name: 'Back', click: () => back(), class: 'button__solid button_secondary'
+            }]
+        }
     let currentStep = 1;
     
     let error, status = "";
@@ -61,7 +73,14 @@
         if(e.type === "contractDetails") {
             txui = "advanced";
         }
-        currentStep = 3; 
+        if (txData.txInfo && txData.txInfo.kwargs && txData.txInfo.kwargs.to){
+            message.text = `The receiving address ${txData.txInfo.kwargs.to} is not a valid Lamden address. Proceeding could result in a loss of funds. Continue?`
+            if (!isLamdenKey(txData.txInfo.kwargs.to)) {
+                currentStep = 3
+                return
+            }
+        }
+        currentStep = 4; 
     }
 
     const createTxDetails = () => {
@@ -106,7 +125,8 @@
     <svelte:component this={Modals[steps[currentStep - 1].page]} 
                       result={resultInfo} 
                       {coin} 
-                      {txData} 
+                      {txData}
+                      {message}
                       txDetails={createTxDetails()}
                       on:txResult={(e) => resultDetails(e)}/>
 {/if}

--- a/src/svelte/coins/CoinLamdenSimpleContract.svelte
+++ b/src/svelte/coins/CoinLamdenSimpleContract.svelte
@@ -154,7 +154,7 @@
     }
 
     const handleReceiverAddrSelect = (e) => {
-        to = e.detail.selected.value.vk;
+        to = e.detail.selected.value.vk.trim();
     }
 
     const handleTokenSelect = (e) => {
@@ -167,13 +167,13 @@
             dispatch('contractSimpleDetails', {
                 sender: from,
                 txInfo: {
-                    senderVk: from.vk,
+                    senderVk: from.vk.trim(),
                     stampLimit: stampLimit,
                     contractName: contractName, 
                     methodName: "transfer", 
                     kwargs: {
                         amount: Encoder("float", amount),
-                        to: Encoder("str", to)
+                        to: Encoder("str", to.trim())
                     }
                 }
             })

--- a/src/svelte/coins/ConiLamdenSendWarningBox.svelte
+++ b/src/svelte/coins/ConiLamdenSendWarningBox.svelte
@@ -1,0 +1,59 @@
+<script>
+    //Images
+    import cautionIcon from '../../img/menu_icons/icon_caution.svg'
+    
+    //Components
+	import { Components }  from '../Router.svelte'
+    const { Button } = Components;
+
+    export let message
+    
+    $: title = message.title;
+    $: text = message.text;
+    $: buttons = message.buttons;
+
+</script>
+
+<style>
+    h2{
+        margin: 1rem 0 0rem;
+    }
+    .notification{
+        width: 530px;
+        align-items: center;
+    }
+    .warning-icon{
+        width: 60px;
+        min-width: 30px;
+    }
+    .msg{
+        margin: 1.6rem 0 1rem 0;
+    }
+    .buttons{
+        flex-grow: 1;
+        flex-direction: column;
+        display: flex;
+        padding-top: 27px;
+        justify-content: center;
+        align-items: center;
+    }
+</style>
+
+<div class="notification flex-column">
+    <div class="warning-icon">{@html cautionIcon}</div>
+    <h2>{title}</h2>
+    <div class="text-body1 msg">
+        {text}
+    </div>
+    <div class="buttons">
+        {#each buttons as button, index}
+            <Button 
+                id={button.id} 
+                classes={button.class} 
+                width={button.width ? button.width : '232px'}
+                margin={button.margin ? button.margin : '0 0 17px 0'}
+                name={button.name}
+                click={button.click} />
+        {/each}
+    </div>
+</div>

--- a/src/svelte/components/Kwargs.svelte
+++ b/src/svelte/components/Kwargs.svelte
@@ -18,7 +18,7 @@
 
     const handleArgChanged = (e) => {
         argumentList.forEach(arg => {
-            if (arg.name === "to" && arg.type === "str") arg.value = arg.value.trim()
+            if (arg.value && arg.name === "to" && arg.type === "str") arg.value = arg.value.trim()
         });
         dispatch('newArgValues', {argumentList, methodIndex})
     }

--- a/src/svelte/confirms/ApproveConnectionTrusted.svelte
+++ b/src/svelte/confirms/ApproveConnectionTrusted.svelte
@@ -34,7 +34,7 @@
     }
 
     const back = () => {
-        dispatch('setStep', 3)
+        dispatch('setStep', 2)
     }    
 </script>
 


### PR DESCRIPTION
Fixes:
- Trim whitespace from lamden keys when creating transactions
- Add a confirm modal which will display when the receiver address is not a LamdenKey.
- Fix the invalid back btn on the trusted popup. (It may be caused by removing ApproveConnectionFund.svelte from the Wallet connection process)
- Fix some errors like "Uncaught TypeError: Cannot read properties of undefined"
- Add new test cases.