### PR TITLE
Added support for a working custom network connection with extension wallet

### DIFF
--- a/src/js/backgroundControllers/masterController.js
+++ b/src/js/backgroundControllers/masterController.js
@@ -337,16 +337,29 @@ export const masterController = () => {
         if (approvalRequest) {
           promptCurrencyApproval(sender, { txData, wallet, dappInfo: info });
         } else {
-          if (dappInfo[txBuilder.type].trustedApp && !forceTxApproval) {
-            transactions.sendLamdenTx(txBuilder, dappInfo.url);
-          } else {
-            promptApproveTransaction(sender, {
-              txData,
-              wallet,
-              dappInfo: info,
-              network,
-            });
-          }
+            if(['mainnet','testnet'].includes(txBuilder.type)){
+		             if (dappInfo[txBuilder.type].trustedApp && !forceTxApproval) {
+		                  transactions.sendLamdenTx(txBuilder, dappInfo.url);
+		             } else {
+                      promptApproveTransaction(sender, {
+                        txData,
+                        wallet,
+                        dappInfo: info,
+                        network,
+                      });
+                 }
+            }else{
+                if (dappInfo[txInfo.networkType].trustedApp && !forceTxApproval) {
+		                 transactions.sendLamdenTx(txBuilder, dappInfo.url);
+		            } else {
+                      promptApproveTransaction(sender, {
+                        txData,
+                        wallet,
+                        dappInfo: info,
+                        network,
+                      });
+                }
+            }
         }
         return callback("ok");
       } catch (err) {

--- a/src/js/backgroundControllers/networkController.js
+++ b/src/js/backgroundControllers/networkController.js
@@ -70,12 +70,22 @@ export const networkController = (utils, services) => {
     }
 
     const getLamdenNetwork = (networkType) => {
-        const foundNetwork = networksStore.lamden.find(network => network.type === networkType.toLowerCase())
-        if (!foundNetwork) return false;
-        return addExtras(new utils.Lamden.Network(foundNetwork))
+    	if(['mainnet','testnet'].includes(networkType)){
+            const foundNetwork = networksStore.lamden.find(network => network.type === networkType.toLowerCase())
+            if (!foundNetwork) return false;
+            return addExtras(new utils.Lamden.Network(foundNetwork))
+        }else{
+            const foundNetwork = networksStore.user.find(network => network.name === networkType.toLowerCase())
+            if (!foundNetwork) return false;
+            return addExtras(new utils.Lamden.Network(foundNetwork))
+        }
     }
 
     const isAcceptedNetwork = (networkType) => {
+        const foundNetwork = networksStore.user.find(network => network.name === networkType.toLowerCase())
+        if(foundNetwork){
+            LamdenNetworkTypes.push(foundNetwork.name)   
+        }
         return LamdenNetworkTypes.includes(networkType)
     }
 


### PR DESCRIPTION
Extension wallet is built to support other networks other than Lamden networks but it cannot properly find custom user network to interact with, hence I added these changes. 

This I feel is important in the case where developers have to run servers locally for active development and testing without having to depend on tesnet or mainnet. Developers should be able to have the same wallet experience as they would with the tesnet or mainnet.

I made just two changes in two files: networkController.js and masterController.js . They are minimal changes but work as they should when sending a transaction. 

 